### PR TITLE
Test ros-controls/ros2_control#635 with a source file for `InterfaceInfo` functions

### DIFF
--- a/.github/workflows/abi_compatibility.yml
+++ b/.github/workflows/abi_compatibility.yml
@@ -17,5 +17,4 @@ jobs:
         env:
           ROS_REPO: ${{matrix.ROS_REPO}}
           ABICHECK_URL: github:ros-controls/ros2_control#${{ env.ROS_DISTRO }}
-          ABICHECK_MERGE: true
           NOT_TEST_BUILD: true

--- a/.github/workflows/abi_compatibility.yml
+++ b/.github/workflows/abi_compatibility.yml
@@ -10,11 +10,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-          ROS_REPO: [main, testing]
+          ROS_REPO: [main]
     steps:
       - uses: actions/checkout@v2
       - uses: ros-industrial/industrial_ci@master
         env:
           ROS_REPO: ${{matrix.ROS_REPO}}
-          ABICHECK_URL: github:ros-controls/ros2_control#${{ github.base_ref }}
+          ABICHECK_URL: github:ros-controls/ros2_control#${{ env.ROS_DISTRO }}
+          ABICHECK_MERGE: true
           NOT_TEST_BUILD: true

--- a/.github/workflows/abi_compatibility.yml
+++ b/.github/workflows/abi_compatibility.yml
@@ -17,4 +17,3 @@ jobs:
         env:
           ROS_REPO: ${{matrix.ROS_REPO}}
           ABICHECK_URL: github:ros-controls/ros2_control#${{ env.ROS_DISTRO }}
-          NOT_TEST_BUILD: true

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ros2_control
+# ros2_control 
 
 [![Licence](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 

--- a/hardware_interface/include/hardware_interface/hardware_info.hpp
+++ b/hardware_interface/include/hardware_interface/hardware_info.hpp
@@ -37,6 +37,8 @@ struct InterfaceInfo
   std::string min;
   /// (Optional) Maximal allowed values of the interface.
   std::string max;
+  /// (Optional) Initial value of the interface.
+  std::string initial_value;
   /// (Optional) The datatype of the interface, e.g. "bool", "int". Used by GPIOs.
   std::string data_type;
   /// (Optional) If the handle is an array, the size of the array. Used by GPIOs.

--- a/hardware_interface/src/component_parser.cpp
+++ b/hardware_interface/src/component_parser.cpp
@@ -38,6 +38,7 @@ constexpr const auto kCommandInterfaceTag = "command_interface";
 constexpr const auto kStateInterfaceTag = "state_interface";
 constexpr const auto kMinTag = "min";
 constexpr const auto kMaxTag = "max";
+constexpr const auto kInitialValueTag = "initial_value";
 constexpr const auto kDataTypeAttribute = "data_type";
 constexpr const auto kSizeAttribute = "size";
 constexpr const auto kNameAttribute = "name";
@@ -256,6 +257,13 @@ hardware_interface::InterfaceInfo parse_interfaces_from_xml(
   if (interface_param != interface_params.end())
   {
     interface.max = interface_param->second;
+  }
+
+  // Optional initial_value attribute
+  interface_param = interface_params.find(kInitialValueTag);
+  if (interface_param != interface_params.end())
+  {
+    interface.initial_value = interface_param->second;
   }
 
   // Default to a single double

--- a/hardware_interface/test/test_component_parser.cpp
+++ b/hardware_interface/test/test_component_parser.cpp
@@ -174,6 +174,8 @@ TEST_F(TestComponentParser, successfully_parse_valid_urdf_system_multi_interface
   EXPECT_EQ(hardware_info.joints[0].type, "joint");
   ASSERT_THAT(hardware_info.joints[0].command_interfaces, SizeIs(3));
   EXPECT_EQ(hardware_info.joints[0].command_interfaces[0].name, HW_IF_POSITION);
+  EXPECT_EQ(hardware_info.joints[0].command_interfaces[0].initial_value, "1.2");
+  EXPECT_EQ(hardware_info.joints[0].command_interfaces[1].initial_value, "3.4");
   ASSERT_THAT(hardware_info.joints[0].state_interfaces, SizeIs(3));
   EXPECT_EQ(hardware_info.joints[0].state_interfaces[1].name, HW_IF_VELOCITY);
 

--- a/ros2_control_test_assets/include/ros2_control_test_assets/components_urdfs.hpp
+++ b/ros2_control_test_assets/include/ros2_control_test_assets/components_urdfs.hpp
@@ -59,10 +59,12 @@ const auto valid_urdf_ros2_control_system_multi_interface =
       <command_interface name="position">
         <param name="min">-1</param>
         <param name="max">1</param>
+        <param name="initial_value">1.2</param>
       </command_interface>
       <command_interface name="velocity">
         <param name="min">-1</param>
         <param name="max">1</param>
+        <param name="initial_value">3.4</param>
       </command_interface>
       <command_interface name="effort">
         <param name="min">-0.5</param>


### PR DESCRIPTION
The ABI compatibility check in ros-controls/ros2_control#635 failed to flag that the proposed changes break ABI compatibility. I will use this PR as a report and a space for discussions. Notice that this PR targets a modified galactic base branch in my fork. Here's what is different about this - I just manually defined a default constructor for `InterfaceInfo` in a separate source file (more on this later):

<details>
<summary>git diff galactic_modified_base origin/galactic</summary>

```diff
diff --git a/hardware_interface/CMakeLists.txt b/hardware_interface/CMakeLists.txt
index fe28e1f..ad44e46 100644
--- a/hardware_interface/CMakeLists.txt
+++ b/hardware_interface/CMakeLists.txt
@@ -22,6 +22,7 @@ add_library(
   src/resource_manager.cpp
   src/sensor.cpp
   src/system.cpp
+  src/hardware_info.cpp
 )
 target_include_directories(
   hardware_interface
diff --git a/hardware_interface/include/hardware_interface/hardware_info.hpp b/hardware_interface/include/hardware_interface/hardware_info.hpp
index db91cd7..61c9a35 100644
--- a/hardware_interface/include/hardware_interface/hardware_info.hpp
+++ b/hardware_interface/include/hardware_interface/hardware_info.hpp
@@ -27,6 +27,7 @@ namespace hardware_interface
  */
 struct InterfaceInfo
 {
+  InterfaceInfo();
   /**
    * Name of the command interfaces that can be set, e.g. "position", "velocity", etc.
    * Used by joints and GPIOs.
diff --git a/hardware_interface/src/hardware_info.cpp b/hardware_interface/src/hardware_info.cpp
new file mode 100644
index 0000000..3fda871
--- /dev/null
+++ b/hardware_interface/src/hardware_info.cpp
@@ -0,0 +1,6 @@
+#include "hardware_interface/hardware_info.hpp"
+
+namespace hardware_interface
+{
+  InterfaceInfo::InterfaceInfo() {}
+}

```

</details>

Before going further, here are version numbers that may be of interest:
- `g++`: 9.3.0
- GNU binutils (`readelf`, `c++filt`, `objdump`): 2.34
- `ctags`: 5.9.0
- `perl`: 5.30.0
- `abi_dumper`: 1.3
- `abi_compliance_checker`: 2.3

Upon investigation, I've observed a few things:

- The [`colcon` invocation](https://github.com/ros-industrial/industrial_ci/blob/25481e5f15476812bde1a223765f602eb07eaa2d/industrial_ci/src/tests/abi_check.sh#L83-L84) in `abi_check.sh` in [ros_industrial/industrial_ci](https://github.com/ros-industrial/industrial_ci) accidentally omits the `-Og` debug flag because the invocation looks like `-DCMAKE_CXX_FLAGS=-g -Og` rather than `-DCMAKE_CXX_FLAGS="-g -Og"`. This is probably inconsequential, but a PR to fix this is in order (https://github.com/ros-industrial/industrial_ci/pull/776).
- The `-extended` mode in `abi_compliance_checker` seems to pick up the ABI breaking change. Check [compat_report_extended.html](https://github.com/aprotyas/ros2_control_bp_593_abi_check_mvp/blob/main/compat_report_extended.html) for the compliance report generated using this option.
FYI, this is what the `-extended` mode does:
```
      If your library A is supposed to be used by other library B and you
      want to control the ABI of B, then you should enable this option. The
      tool will check for changes in all data types, even if they are not
      used by any function in the library A. Such data types are not part
      of the A library ABI, but may be a part of the ABI of the B library.
```
I'm not sure why this is needed because `hardware_interface` is a single shared library.
- It looks like when the class in question (`InterfaceInfo`) somehow has methods defined in a separate translation unit - i.e. it's not a header-only type - the ABI compatibility checker seems to pick up the problem locally. This should be verified when a CI workflow runs for this PR. I'm not sure what the reason for this is: are the header-only type symbols not exported? To be honest, I'm not sure how some of this works so any insight would be appreciated.

Some talking points:

- Is this behavior a bug - or at least questionable - on the compliance checker's end? If so, this should be filed as an issue upstream.
- Should the `-extend` option be enabled by default in industrial_ci's ABI check?

FYI @bmagyar @destogl.